### PR TITLE
[Bashrc] Remove Combined History

### DIFF
--- a/bashrcs/main.bashrc.sh
+++ b/bashrcs/main.bashrc.sh
@@ -56,7 +56,12 @@ HISTFILESIZE=100000  # commands in history file.
 shopt -s histappend  # append to HISTFILE instead of overwriting.
 # Hack to merge history across terminals.
 # NOTE: a command has to be run in the terminal in order for them to sync.
-PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"
+#
+# I actually don't like this ... I need to think of something else...
+# I get value out of having separate histories in my bash sessions.
+# The real reason why I wanted these merged is to search command history from +1days ago.
+# I think that I can solve this problem a different way.
+# PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"
 
 ### Fuzzy Finder
 if [ -e /usr/share/fzf/key-bindings.bash ]; then


### PR DESCRIPTION
I was trying to solve, "how do I search my history from days ago in a terminal ... I can't remember which one it was!?" by combining the history of all terminals. However, it turns out that I prefer having different history queues per process ... I can solve the real problem in some different way.